### PR TITLE
Prevent array files from transforming to objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function GenerateJsonFromJsPlugin (config = {}) {
     ...config,
     filePath: config.path,
     filename: config.filename,
-    data: config.data || {},
+    data: config.data || [],
     options: {
       ...defaultJsonOptions,
       ...config.options
@@ -34,6 +34,11 @@ GenerateJsonFromJsPlugin.prototype.apply = function apply (compiler) {
 
     if (typeof jsModule === 'function') {
       jsonValue = jsModule(this.data)
+    } else if (jsModule instanceof Array) {
+      jsonValue = [
+        ...jsModule,
+        ...this.data,
+      ]
     } else if (typeof jsModule === 'object') {
       jsonValue = {
         ...jsModule,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generate-json-from-js-webpack-plugin",
+  "name": "generate-json-from-js-webpack-plugin-iman",
   "version": "0.1.2",
   "description": "A webpack plugin that generates a custom JSON asset from a JS module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-json-from-js-webpack-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A webpack plugin that generates a custom JSON asset from a JS module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
You can now pass arrays and have them in proper format as JSON file. 